### PR TITLE
add missing word: branch

### DIFF
--- a/manuscript/08-pr.md
+++ b/manuscript/08-pr.md
@@ -44,7 +44,7 @@ We'll continue using the *go-demo-6* application. Please enter the local copy of
 cd go-demo-6
 ```
 
-I> The commands that follow will reset your `master` with the contents of the `dev` branch that contains all the changes we did so far. Please execute them only if you are unsure whether you did all the exercises correctly.
+I> The commands that follow will reset your `master` branch with the contents of the `dev` branch that contains all the changes we did so far. Please execute them only if you are unsure whether you did all the exercises correctly.
 
 ```bash
 git pull


### PR DESCRIPTION
I think this should be `master branch` instead of just `master`?
Not entirely sure how this works in English, but I believe in English it is generally considered to be explicit with types.
As in, in Dutch, I can say `a Y- and a Xtable` but in English I think it should be `a Y-table and X-table`.