### PR TITLE
Joostvdg patch 4

### DIFF
--- a/manuscript/08-pr.md
+++ b/manuscript/08-pr.md
@@ -313,7 +313,7 @@ jx create issue -t "Add unit tests" \
     -b
 ```
 
-W> If you're getting an error along the like `410 Issues are disabled for this repo []` you will have to enable issues manually. Open the issues page, go to the `Features` heading, and enable `Issues` by checking the checkbox. And then issue the above command again.
+W> If you're getting an error along the like `410 Issues are disabled for this repo []` you will have to enable settings manually. Open the issues page, go to the `Features` heading, and enable `Issues` by checking the checkbox. And then issue the above command again.
 
 ```
 open https://github.com/${GH_USER}/go-demo-6/settings


### PR DESCRIPTION
Add section on enabling issues on your repo.
For some reason, my `issues` were disabled on the `go-demo-6` repo.
I might not be the only one, so adding some help for this