### PR TITLE
Suggested edits from working through the material

### DIFF
--- a/manuscript/04-import.md
+++ b/manuscript/04-import.md
@@ -228,7 +228,7 @@ When in doubt, we can always take a look at the logs.
 
 ```bash
 kubectl --namespace jx-staging logs \
-    -l app=jx-staging-go-demo-6
+    -l app=jx-go-demo-6
 ```
 
 The output is as follows.
@@ -353,10 +353,10 @@ The output is as follows.
 
 ```
 NAME                                READY STATUS  RESTARTS AGE
-jx-staging-go-demo-6-...            0/1   Running 5        5m
-jx-staging-go-demo-6-db-arbiter-0   1/1   Running 0        5m
-jx-staging-go-demo-6-db-primary-0   1/1   Running 0        5m
-jx-staging-go-demo-6-db-secondary-0 1/1   Running 0        5m
+jx-go-demo-6-...            0/1   Running 5        5m
+jx-go-demo-6-db-arbiter-0   1/1   Running 0        5m
+jx-go-demo-6-db-primary-0   1/1   Running 0        5m
+jx-go-demo-6-db-secondary-0 1/1   Running 0        5m
 ```
 
 The good news is that the database is indeed running. The bad news is that the application is still not operational. In my case, it already restarted five times, and `0` containers are available.
@@ -366,7 +366,7 @@ Given that the problem is this time probably not related to the database, the lo
 ```bash
 kubectl --namespace jx-staging \
     describe pod \
-    -l app=jx-staging-go-demo-6
+    -l app=jx-go-demo-6
 ```
 
 The output, limited to the message of the events, is as follows.
@@ -376,7 +376,7 @@ The output, limited to the message of the events, is as follows.
 Events:
 ... Message
 ... -------
-... Successfully assigned jx-staging-go-demo-6-fdd8f6644-xx68f to gke-jx-rocks-default-pool-119fec1e-v7p7
+... Successfully assigned jx-go-demo-6-fdd8f6644-xx68f to gke-jx-rocks-default-pool-119fec1e-v7p7
 ... MountVolume.SetUp succeeded for volume "default-token-cxn5p"
 ... Readiness probe failed: Get http://10.28.2.17:8080/: dial tcp 10.28.2.17:8080: getsockopt: connection refused
 ... Back-off restarting failed container
@@ -428,10 +428,10 @@ The output is as follows.
 
 ```
 NAME                                READY STATUS  RESTARTS AGE
-jx-staging-go-demo-6-...            1/1   Running 0        39s
-jx-staging-go-demo-6-db-arbiter-0   1/1   Running 0        11m
-jx-staging-go-demo-6-db-primary-0   1/1   Running 0        11m
-jx-staging-go-demo-6-db-secondary-0 1/1   Running 0        11m
+jx-go-demo-6-...            1/1   Running 0        39s
+jx-go-demo-6-db-arbiter-0   1/1   Running 0        11m
+jx-go-demo-6-db-primary-0   1/1   Running 0        11m
+jx-go-demo-6-db-secondary-0 1/1   Running 0        11m
 ```
 
 To be on the safe side, we'll send a request to the application. If we are greeted back, we'll know that it's working as expected.

--- a/manuscript/05-buildpacks.md
+++ b/manuscript/05-buildpacks.md
@@ -152,7 +152,7 @@ The next in line of the files we have to change is the `requirements.yaml` file.
 ```bash
 echo "dependencies:
 - name: mongodb
-  alias: code-db
+  alias: REPLACE_ME_APP_NAME-db
   version: 5.3.0
   repository:  https://kubernetes-charts.storage.googleapis.com
   condition: db.enabled
@@ -164,7 +164,7 @@ Please note the usage of the `code` string. Today (February 2019), that is still
 Now that we created the `mongodb` dependency, we should add the values that will customize MongoDB chart so that the database is deployed as a MongoDB replica set (a Kubernetes StatefulSet with two or more replicas). The place where we change variables used with a chart is `values.yaml`. But, since we want to redefine values of dependency, we need to add it inside the name or, in our case, the alias of that dependency.
 
 ```bash
-echo "code-db:
+echo "REPLACE_ME_APP_NAME-db:
   replicaSet:
     enabled: true
 " | tee -a packs/go-mongo/charts/values.yaml
@@ -373,10 +373,10 @@ The output is as follows.
 
 ```
 NAME                                READY STATUS  RESTARTS AGE
-jx-staging-go-demo-6-...            0/1   Running 2        2m
-jx-staging-go-demo-6-db-arbiter-0   1/1   Running 0        2m
-jx-staging-go-demo-6-db-primary-0   1/1   Running 0        2m
-jx-staging-go-demo-6-db-secondary-0 1/1   Running 0        2m
+jx-go-demo-6-...            0/1   Running 2        2m
+jx-go-demo-6-db-arbiter-0   1/1   Running 0        2m
+jx-go-demo-6-db-primary-0   1/1   Running 0        2m
+jx-go-demo-6-db-secondary-0 1/1   Running 0        2m
 ```
 
 The database Pods seem to be running correctly, so the new pack was indeed applied. However, the application Pod is restarting. From the past experience, you probably already know what the issue is. If you forgot, please execute the command that follows.
@@ -384,7 +384,7 @@ The database Pods seem to be running correctly, so the new pack was indeed appli
 ```bash
 kubectl --namespace jx-staging \
     describe pod \
-    -l app=jx-staging-go-demo-6
+    -l app=jx-go-demo-6
 ```
 
 We can see from the events that the probes are failing. That was to be expected since we decided that hard-coding `probePath` to `/demo/hello?health=true` is likely not going to be useful to anyone but the *go-demo-6* application. So, we left it as `/` in our `go-mongo` build pack. Owners of the applications that will use our new build pack should change it if needed. Therefore, we'll need to modify the application to accommodate the "special" probe path.

--- a/manuscript/05-buildpacks.sh
+++ b/manuscript/05-buildpacks.sh
@@ -28,13 +28,13 @@ cat packs/go-mongo/charts/templates/deployment.yaml \
 
 echo "dependencies:
 - name: mongodb
-  alias: code-db
+  alias: REPLACE_ME_APP_NAME-db
   version: 5.3.0
   repository:  https://kubernetes-charts.storage.googleapis.com
   condition: db.enabled
 " | tee packs/go-mongo/charts/requirements.yaml
 
-echo "code-db:
+echo "REPLACE_ME_APP_NAME-db:
   replicaSet:
     enabled: true
 " | tee -a packs/go-mongo/charts/values.yaml
@@ -104,7 +104,7 @@ kubectl --namespace jx-staging get pods
 
 kubectl --namespace jx-staging \
     describe pod \
-    -l app=jx-staging-go-demo-6
+    -l app=jx-go-demo-6
 
 cat charts/go-demo-6/values.yaml
 

--- a/manuscript/07-dev.md
+++ b/manuscript/07-dev.md
@@ -138,7 +138,7 @@ Next, Jenkins X installed the `ExposecontrollerService`. It will communicate wit
 
 Further on, it updated the Helm repository in the DevPod so that we can utilize the charts available in ChartMuseum running inside the cluster.
 
-It also run Theia. We'll keep it a mystery for now.
+It also ran Theia. We'll keep it a mystery for now.
 
 Finally, it cloned the *go-demo-6* code inside the Pod.
 
@@ -419,14 +419,14 @@ jenkins-x-monocular-api   http://monocular.jx.34.73.126.76.nip.io
 jenkins-x-monocular-ui    http://monocular.jx.34.73.126.76.nip.io
 vfarcic-go-port-2345      http://vfarcic-go-port-2345.jx.34.73.126.76.nip.io
 vfarcic-go-port-8080      http://vfarcic-go-port-8080.jx.34.73.126.76.nip.io
-vfarcic-go-theia          http://vfarcic-go-theia.jx.34.73.126.76.nip.io
+vfarcic-go-ide            http://vfarcic-go-ide.jx.34.73.126.76.nip.io
 ```
 
-The `open` command lists all the applications managed by Jenkins X and running inside our cluster. We can see that one of them is `theia` prefixed with our username and the programming language we're using. In my case that's `vfarcic-go-theia`.
+The `open` command lists all the applications managed by Jenkins X and running inside our cluster. We can see that one of them is `ide` prefixed with our username and the programming language we're using. In my case that's `vfarcic-go-ide`.
 
 If we add the name of the application as an argument to the `jx open` command, it'll (surprise, surprise) open that application in the default browser. Let's try it out.
 
-Please replace `[...]` with the name of the `*-theia` application before executing the command that follows.
+Please replace `[...]` with the name of the `*-ide` application before executing the command that follows.
 
 ```bash
 jx open [...]

--- a/manuscript/07-dev.sh
+++ b/manuscript/07-dev.sh
@@ -34,7 +34,7 @@ cat skaffold.yaml \
     "s@vfarcic@$PROJECT@g" \
     | tee skaffold.yaml
 
-jx import --pack go --batch-modes
+jx import --pack go --batch-mode
 
 jx get activity -f go-demo-6 -w
 

--- a/manuscript/11-serverless.md
+++ b/manuscript/11-serverless.md
@@ -28,7 +28,7 @@ If we spin up pipeline-runners on demand and we destroy them when builds are fin
 
 I> I really dislike the word "serverless" because it is misleading. It makes you believe that there are no servers involved. It should rather be called servers-not-managed-by-us. Nevertheless, I will continue using the word serverless to describe processes that spin up on demand and get destroyed when done, simply because that is the most commonly used name today.
 
-Jenkins X  in serverless mode uses [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) as highly available API that receives webhook requests. Jenkins is replaced with Jenkins X Pipeline Operator and [Tekton](https://cloud.google.com/tekton/). It translates the events coming to Prow into Tekton pipelines. Given that Tekton is very low-level and its pipelines are hard to define, Pipeline operator translates Jenkins pipelines into Tekton Pipelines which, in turn, spin up Tekton Tasks, one for each step of the pipeline. Those pipelines are defined in jenkins-x.yml.
+Jenkins X  in serverless mode uses [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) as the highly available API that receives webhook requests. Jenkins is replaced with Jenkins X Pipeline Operator and [Tekton](https://cloud.google.com/tekton/). It translates the events coming to Prow into Tekton pipelines. Given that Tekton is very low-level and its pipelines are hard to define, Pipeline operator translates Jenkins pipelines into Tekton Pipelines which, in turn, spin up Tekton Tasks, one for each step of the pipeline. Those pipelines are defined in jenkins-x.yml.
 
 ![Figure 11-5: Serverless flavor of Jenkins X](images/ch11/serverless.png)
 


### PR DESCRIPTION
These edits and notes are based on working through the book with Jenkins X 2.0.598 through 2.0.681. Using GKE via local jx install on macOS.

In addition to the edits in the PR, here are some notes I took that might warrant further investigation.

- For DevPod chapter, to get Theia IDE need to specify --theia=true, default is now VS Studio Code. 
- Synchronizing Code From A Laptop Into A DevPod - watch.sh is failing apparently due to build issue.
- In ChatOps chapter note that additional OWNERS content needs to be on master branch to take effect.
- In Knative chapter, there's a missing required field in the ksvc template: add readinessProbe.failureThreshold. Needs to be added in ksvc.yaml template and values.yaml for go-demo-6 knative conversion.
- Had a number of struggles (no notes - sorry) in the Knative chapter and then early  in the deployment strategy chapter with the Knative config (gave up on fixing this one). This was the only part of the book that really had me in knots - may want to revisit these instructions.
- Could consider locking down to a specified version of jx since a lot is in flux - would help to stabilize the instructions. That said I understand the advantages of keeping up with the latest and I think the target audience can roll with the mostly minor challenges.

I do want to thank you again - this was a fantastic resource for getting familiar with jx!
